### PR TITLE
Add support for ?max-count param to /api/runs

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -57,7 +57,15 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var testRuns []TestRun
-	baseQuery := datastore.NewQuery("TestRun").Order("-CreatedAt").Limit(1)
+	var limit int
+	if limit, err = ParseMaxCountParam(r); err != nil {
+		http.Error(w, "Invalid 'max-count' param: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	baseQuery := datastore.
+		NewQuery("TestRun").
+		Order("-CreatedAt").
+		Limit(limit)
 
 	for _, browserName := range browserNames {
 		var testRunResults []TestRun
@@ -115,7 +123,6 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := appengine.NewContext(r)
-
 	query := datastore.
 		NewQuery("TestRun").
 		Order("-CreatedAt").

--- a/params.go
+++ b/params.go
@@ -19,8 +19,18 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
+
+// MaxCountDefaultValue is the default value returned by ParseMaxCountParam for the max-count param.
+const MaxCountDefaultValue = 1
+
+// MaxCountMaxValue is the maximum allowed value for the max-count param.
+const MaxCountMaxValue = 500
+
+// MaxCountMinValue is the minimum allowed value for the max-count param.
+const MaxCountMinValue = 1
 
 // ParseSHAParam parses and validates the 'sha' param for the request.
 // It returns "latest" by default (and in error cases).
@@ -86,4 +96,21 @@ func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
 	}
 	sort.Strings(browsers)
 	return browsers, nil
+}
+
+// ParseMaxCountParam parses the 'max-count' parameter as an integer.
+func ParseMaxCountParam(r *http.Request) (count int, err error) {
+	count = MaxCountDefaultValue
+	if browsersParam := r.URL.Query().Get("max-count"); browsersParam != "" {
+		if count, err = strconv.Atoi(browsersParam); err != nil {
+			return MaxCountDefaultValue, err
+		}
+		if count < MaxCountMinValue {
+			count = MaxCountMinValue
+		}
+		if count > MaxCountMaxValue {
+			count = MaxCountMaxValue
+		}
+	}
+	return count, err
 }

--- a/params_test.go
+++ b/params_test.go
@@ -140,3 +140,31 @@ func TestParseBrowsersParam_MultiBrowserParam_AllInvalid(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Empty(t, browsers)
 }
+
+func TestParseMaxCountParam(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=2", nil)
+	count, err := ParseMaxCountParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestParseMaxCountParam_Missing(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
+	count, err := ParseMaxCountParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, MaxCountDefaultValue, count)
+}
+
+func TestParseMaxCountParam_TooSmall(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=0", nil)
+	count, err := ParseMaxCountParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, MaxCountMinValue, count)
+}
+
+func TestParseMaxCountParam_TooLarge(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=123456789", nil)
+	count, err := ParseMaxCountParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, MaxCountMaxValue, count)
+}


### PR DESCRIPTION
Builds on https://github.com/w3c/wptdashboard/pull/280