### PR TITLE
Shorten longer shas to 10 chars

### DIFF
--- a/webapp/params.go
+++ b/webapp/params.go
@@ -26,7 +26,7 @@ const MaxCountMaxValue = 500
 const MaxCountMinValue = 1
 
 // SHARegex is a regex for SHA[0:10] slice of a git hash.
-var SHARegex = regexp.MustCompile("[0-9a-fA-F]{10}")
+var SHARegex = regexp.MustCompile("[0-9a-fA-F]{10,40}")
 
 // ParseSHAParam parses and validates the 'sha' param for the request.
 // It returns "latest" by default (and in error cases).
@@ -40,7 +40,7 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 
 	runParam := params.Get("sha")
 	if SHARegex.MatchString(runParam) {
-		runSHA = runParam
+		runSHA = runParam[:10]
 	}
 	return runSHA, err
 }

--- a/webapp/params_test.go
+++ b/webapp/params_test.go
@@ -26,6 +26,14 @@ func TestParseSHAParam_2(t *testing.T) {
 	assert.Equal(t, sha, runSHA)
 }
 
+func TestParseSHAParam_FullSHA(t *testing.T) {
+	sha := "0123456789aaaaabbbbbcccccdddddeeeeefffff"
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
+	runSHA, err := ParseSHAParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, sha[:10], runSHA)
+}
+
 func TestParseSHAParam_BadRequest(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=%zz", nil)
 	runSHA, err := ParseSHAParam(r)


### PR DESCRIPTION
Handles ?sha=[full sha] requests correctly.