### PR TITLE
Add firefox webdriver test + install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bq-schema
 generated
 webapp/bower_components/*
 !webapp/bower_components/{polymer,shadycss,webcomponentsjs}
+webdriver/selenium-server-standalone*
+webdriver/geckodriver*
+webdriver/firefox-58.0*

--- a/webdriver/firefox.go
+++ b/webdriver/firefox.go
@@ -1,0 +1,79 @@
+package webdriver
+
+import (
+	"flag"
+	"fmt"
+	"github.com/tebeka/selenium"
+	"github.com/tebeka/selenium/firefox"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	seleniumPath     = flag.String("selenium_path", "selenium-server-standalone-3.8.1.jar", "Path to the selenium standalone binary.")
+	geckoDriverPath  = flag.String("geckodriver_path", "geckodriver-v0.19.1", "Path to the geckodriver binary")
+	firefoxPath      = flag.String("firefox_path", firefoxPathDefault(), "Path to the firefox binary")
+	startFrameBuffer = flag.Bool("frame_buffer", frameBufferDefault(), "Whether to use a frame buffer")
+	seleniumHost     = flag.String("selenium_host", "localhost", "Host to run selenium on")
+	seleniumPort     = flag.Int("selenium_port", 8888, "Port to run selenium on")
+)
+
+func firefoxPathDefault() string {
+	internalPath := "firefox"
+	if runtime.GOOS == "darwin" {
+		internalPath = "Contents/MacOS/firefox"
+	}
+	return fmt.Sprintf("firefox-58.0/%s", internalPath)
+}
+
+func frameBufferDefault() bool {
+	return runtime.GOOS != "darwin"
+}
+
+// FirefoxWebDriver starts up a Firefox WebDriver.
+// Make sure to close both the service and the WebDriver instances, e.g.
+//
+// s, d, e := FirefoxWebDriver()
+// if e != nil {
+//   panic(e)
+// }
+// defer s.Stop()
+// defer wd.Quit()
+func FirefoxWebDriver() (*selenium.Service, selenium.WebDriver, error) {
+	var options []selenium.ServiceOption
+	// Start an X frame buffer for the browser to run in.
+	if *startFrameBuffer {
+		options = append(options, selenium.StartFrameBuffer())
+	}
+	// Specify the path to GeckoDriver in order to use Firefox.
+	options = append(options, selenium.GeckoDriver(*geckoDriverPath))
+	// Output debug information to STDERR.
+	options = append(options, selenium.Output(os.Stderr))
+
+	selenium.SetDebug(true)
+	service, err := selenium.NewSeleniumService(*seleniumPath, *seleniumPort, options...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Connect to the WebDriver instance running locally.
+	seleniumCapabilities := selenium.Capabilities{
+		"browserName": "firefox",
+	}
+
+	firefoxCapabilities := firefox.Capabilities{}
+	// Selenium 2 uses this option to specify the path to the Firefox binary.
+	// seleniumCapabilities["firefox_binary"] = c.path
+	firefoxAbsPath, err := filepath.Abs(*firefoxPath)
+	if err != nil {
+		panic(err)
+	}
+	firefoxCapabilities.Binary = firefoxAbsPath
+	seleniumCapabilities.AddFirefox(firefoxCapabilities)
+
+	wd, err := selenium.NewRemote(
+		seleniumCapabilities,
+		fmt.Sprintf("http://%s:%d/wd/hub", *seleniumHost, *seleniumPort))
+	return service, wd, err
+}

--- a/webdriver/install.sh
+++ b/webdriver/install.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Fetch needed webdriver dependencies.
+
+DOCKER_DIR=$(dirname "$0")
+source "${DOCKER_DIR}/../util/logging.sh"
+source "${DOCKER_DIR}/../util/path.sh"
+
+usage() {
+  info "Usage: install.sh [-r]\n-r - Reinstall";
+}
+
+REINSTALL="false"
+while getopts ':r' flag; do
+  case "${flag}" in
+    r) REINSTALL='true' ;;
+    h|*) usage && exit 0;;
+  esac
+done
+
+# fetch [url] [filename]
+# Downloads [url] if [filename] doesn't already exist.
+function fetch () {
+    if [[ -e $2 ]]
+    then
+        info "$2 already present."
+    else
+        wget "$1" "$2"
+    fi
+}
+
+# Selenium standalone.
+SELENIUM_STANDALONE="selenium-server-standalone-3.8.1.jar"
+SELENIUM_STANDALONE_URL="http://selenium-release.storage.googleapis.com/3.8/${SELENIUM_STANDALONE}"
+
+fetch "${SELENIUM_STANDALONE_URL}" "${SELENIUM_STANDALONE}"
+
+# Gecko driver
+GECKO_DRIVER="geckodriver-v0.19.1"
+UNAME_OUT="$(uname -s)"
+case "${UNAME_OUT}" in
+    Darwin*)   GECKO_DRIVER_OS="macos";;
+    Linux*|*)  GECKO_DRIVER_OS="linux64";;
+esac
+GECKO_DRIVER_TAR="${GECKO_DRIVER}-${GECKO_DRIVER_OS}.tar"
+GECKO_DRIVER_GZ="${GECKO_DRIVER_TAR}.gz"
+GECKO_DRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v0.19.1/${GECKO_DRIVER_GZ}"
+
+info "Getting ${GECKO_DRIVER} binary..."
+if [[ ! -e ${GECKO_DRIVER} || "${REINSTALL}" == "true" ]]
+then
+    info "Downloading ${GECKO_DRIVER_URL}..."
+    fetch ${GECKO_DRIVER_URL} ${GECKO_DRIVER_GZ}
+
+    info "Unzipping ${GECKO_DRIVER_GZ}..."
+    if [[ ! -e ${GECKO_DRIVER_TAR} ]]; then gunzip -k ${GECKO_DRIVER_GZ}; fi
+
+    info "Unzipping ${GECKO_DRIVER_TAR}..."
+    if [[ ! -e geckodriver || "${REINSTALL}" == "true" ]]; then tar -xf ${GECKO_DRIVER_TAR}; fi
+
+    if [[ -e "${GECKO_DRIVER}" && "${REINSTALL}" == "true" ]]
+    then
+        info "Removing existing ${GECKO_DRIVER}..."
+        rm ${GECKO_DRIVER}
+    fi
+
+    info "Renaming to ${GECKO_DRIVER}..."
+    mv geckodriver ${GECKO_DRIVER}
+fi
+
+# Firefox 58
+FIREFOX="firefox-58.0"
+case "${UNAME_OUT}" in
+    Darwin*)
+        FIREFOX_OS="mac"
+        FIREFOX_DMG="Firefox 58.0.dmg"
+        FIREFOX_SRC="${FIREFOX_DMG}"
+        ;;
+    Linux*|*)
+        FIREFOX_OS="linux-x86_64"
+        FIREFOX_TAR="${FIREFOX}.tar"
+        FIREFOX_BZ="${FIREFOX_TAR}.bz2"
+        FIREFOX_SRC="${FIREFOX_BZ}"
+        ;;
+esac
+FIREFOX_URL="https://releases.mozilla.org/pub/firefox/releases/58.0/${FIREFOX_OS}/en-US/${FIREFOX_SRC}"
+
+info "Getting ${FIREFOX} binary..."
+if [[ ! -e ${FIREFOX} || "${REINSTALL}" == "true" ]]
+then
+    if [[ -e ${FIREFOX} && "${REINSTALL}" == "true" ]]
+    then
+        warn "Removing existing ${FIREFOX} dir..."
+        rm -r ${FIREFOX}
+    fi
+
+    info "Downloading ${FIREFOX_URL}..."
+    fetch "${FIREFOX_URL}" "${FIREFOX_SRC}"
+
+    if [[ "${FIREFOX_DMG}" != "" ]]
+    then
+        hdiutil attach "${FIREFOX_DMG}"
+        FIREFOX_CP_CMD="cp -R /Volumes/Firefox/Firefox.app ${FIREFOX}"
+        info "${FIREFOX_CP_CMD}"
+        ${FIREFOX_CP_CMD}
+        hdiutil detach "/Volumes/Firefox"
+    elif [[ "${FIREFOX_BZ}" != "" ]]
+    then
+        info "Unzipping ${FIREFOX_BZ}..."
+        if [[ ! -e ${FIREFOX_TAR} || "${REINSTALL}" == "true" ]]; then bzip2 -dkf ${FIREFOX_BZ}; fi
+
+        info "Unzipping ${FIREFOX_TAR}..."
+        if [[ ! -e firefox || "${REINSTALL}" == "true" ]]; then tar -xf ${FIREFOX_TAR}; fi
+
+        info "Renaming to ${FIREFOX}..."
+        mv firefox ${FIREFOX}
+    fi
+fi

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -1,0 +1,130 @@
+package webdriver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tebeka/selenium"
+	"github.com/w3c/wptdashboard/shared"
+	"google.golang.org/appengine/datastore"
+	"log"
+)
+
+func TestSearch(t *testing.T) {
+	devAppserverInstance, err := NewWebserver()
+	if err != nil {
+		panic(err)
+	}
+	defer devAppserverInstance.Close()
+	if err = devAppserverInstance.AwaitReady(); err != nil {
+		panic(err)
+	}
+
+	if err = addStaticData(devAppserverInstance); err != nil {
+		panic(err)
+	}
+
+	service, wd, err := FirefoxWebDriver()
+	defer service.Stop()
+	defer wd.Quit()
+
+	// Navigate to the wpt.fyi homepage.
+	if err := wd.Get(devAppserverInstance.GetWebappUrl("/")); err != nil {
+		panic(err)
+	}
+
+	// Wait for the results view to load.
+	runsLoadedCondition := func(wd selenium.WebDriver) (bool, error) {
+		results, err := wd.FindElements(selenium.ByCSSSelector, "path-part")
+		if err != nil {
+			return false, err
+		}
+		return len(results) > 0, nil
+	}
+	wd.WaitWithTimeout(runsLoadedCondition, time.Second*10)
+
+	// Run the search
+	searchBox, err := wd.FindElement(selenium.ByCSSSelector, "input.query")
+	if err != nil {
+		panic(err)
+	}
+
+	const query = "2dcontext"
+	if err := searchBox.SendKeys(query); err != nil {
+		panic(err)
+	}
+
+	results, err := wd.FindElements(selenium.ByCSSSelector, "path-part")
+	if err != nil {
+		panic(err)
+	}
+	assert.Lenf(t, results, 1, "Expected exactly 1 '%s' search result.", query)
+	text, err := results[0].Text()
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	assert.Equal(t, "2dcontext/", text)
+}
+
+func addStaticData(i WebserverInstance) (err error) {
+	var ctx context.Context
+	if ctx, err = i.NewContext(); err != nil {
+		return err
+	}
+
+	staticDataTime, _ := time.Parse(time.RFC3339, "2017-10-18T00:00:00Z")
+	// Follow pattern established in run/*.py data collection code.
+	const sha = "b952881825"
+	const summaryUrlFmtString = "/static/" + sha + "/%s"
+	staticTestRuns := []shared.TestRun{
+		{
+			BrowserName:    "chrome",
+			BrowserVersion: "63.0",
+			OSName:         "linux",
+			OSVersion:      "3.16",
+			Revision:       sha,
+			ResultsURL:     fmt.Sprintf(summaryUrlFmtString, "chrome-63.0-linux-summary.json.gz"),
+			CreatedAt:      staticDataTime,
+		},
+		{
+			BrowserName:    "edge",
+			BrowserVersion: "15",
+			OSName:         "windows",
+			OSVersion:      "10",
+			Revision:       sha,
+			ResultsURL:     fmt.Sprintf(summaryUrlFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
+			CreatedAt:      staticDataTime,
+		},
+		{
+			BrowserName:    "firefox",
+			BrowserVersion: "57.0",
+			OSName:         "linux",
+			OSVersion:      "*",
+			Revision:       sha,
+			ResultsURL:     fmt.Sprintf(summaryUrlFmtString, "firefox-57.0-linux-summary.json.gz"),
+			CreatedAt:      staticDataTime,
+		},
+		{
+			BrowserName:    "safari",
+			BrowserVersion: "10",
+			OSName:         "macos",
+			OSVersion:      "10.12",
+			Revision:       sha,
+			ResultsURL:     fmt.Sprintf(summaryUrlFmtString, "safari-10.0-macos-10.12-sauce-summary.json.gz"),
+			CreatedAt:      staticDataTime,
+		},
+	}
+
+	log.Println("Adding static TestRun data...")
+	for i := range staticTestRuns {
+		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+		if _, err := datastore.Put(ctx, key, &staticTestRuns[i]); err != nil {
+			return err
+		}
+		fmt.Printf("Added static run for %s\n", staticTestRuns[i].BrowserName)
+	}
+	return nil
+}

--- a/webdriver/webapp.go
+++ b/webdriver/webapp.go
@@ -1,0 +1,193 @@
+package webdriver
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/appengine/remote_api"
+	"net/http"
+	"path/filepath"
+	"syscall"
+)
+
+type WebserverInstance interface {
+	// Hook for closing the process that runs the webserver.
+	io.Closer
+
+	// GetWebappUrl returns the URL for the given path on the running webapp.
+	GetWebappUrl(path string) string
+
+	// AwaitReady starts the Webserver command and waits until the output has
+	// said the server is running.
+	AwaitReady() error
+
+	// NewContext creates a context object backed by a remote api HTTP request.
+	NewContext() (context.Context, error)
+}
+
+type instance struct {
+	cmd            *exec.Cmd
+	stderr         io.Reader
+	startupTimeout time.Duration
+
+	host      string
+	port      int
+	adminPort int
+	apiPort   int
+
+	baseURL  *url.URL
+	adminURL *url.URL
+}
+
+func (i *instance) GetWebappUrl(path string) string {
+	if i.baseURL != nil {
+		return fmt.Sprintf("%s%s", i.baseURL.String(), path)
+	}
+	return fmt.Sprintf("http://%s:%d%s", i.host, i.port, path)
+}
+
+func (i *instance) Close() error {
+	errc := make(chan error, 1)
+	go func() {
+		errc <- i.cmd.Wait()
+	}()
+
+	// Call the quit handler on the admin server.
+	res, err := http.Get(i.adminURL.String() + "/quit")
+	if err != nil {
+		i.cmd.Process.Kill()
+		return fmt.Errorf("unable to call /quit handler: %v", err)
+	}
+	res.Body.Close()
+
+	select {
+	case <-time.After(15 * time.Second):
+		i.cmd.Process.Kill()
+		return errors.New("timeout killing child process")
+	case err = <-errc:
+		// Do nothing.
+	}
+	return err
+}
+
+func NewWebserver() (s WebserverInstance, err error) {
+	i := &instance{
+		startupTimeout: 15 * time.Second,
+
+		host:      "localhost",
+		port:      8080,
+		adminPort: 8000,
+		apiPort:   9999,
+	}
+
+	i.cmd = exec.Command(
+		"dev_appserver.py",
+		fmt.Sprintf("--port=%d", i.port),
+		fmt.Sprintf("--admin_port=%d", i.adminPort),
+		fmt.Sprintf("--api_port=%d", i.apiPort),
+		"--automatic_restart=false",
+		"--skip_sdk_update_check=true",
+		"--clear_datastore=true",
+		"--clear_search_indexes=true",
+		"-A=wptdashboard",
+		"../webapp",
+	)
+
+	s = WebserverInstance(i)
+	i.cmd.Stdout = os.Stdout
+
+	var stderr io.Reader
+	stderr, err = i.cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	i.stderr = io.TeeReader(stderr, os.Stderr)
+	return s, err
+}
+
+var readyRE = regexp.MustCompile(`Starting module "default" running at: (\S+)`)
+var adminUrlRE = regexp.MustCompile(`Starting admin server at: (\S+)`)
+
+func (i *instance) AwaitReady() error {
+	if err := i.cmd.Start(); err != nil {
+		return err
+	}
+
+	// Read stderr until we have read the URLs of the API server and admin interface.
+	errc := make(chan error, 1)
+	go func() {
+		s := bufio.NewScanner(i.stderr)
+		for s.Scan() {
+			if match := readyRE.FindStringSubmatch(s.Text()); match != nil {
+				u, err := url.Parse(match[1])
+				if err != nil {
+					errc <- fmt.Errorf("failed to parse URL %q: %v", match[1], err)
+					return
+				}
+				i.baseURL = u
+			}
+			if match := adminUrlRE.FindStringSubmatch(s.Text()); match != nil {
+				u, err := url.Parse(match[1])
+				if err != nil {
+					errc <- fmt.Errorf("failed to parse URL %q: %v", match[1], err)
+					return
+				}
+				i.adminURL = u
+			}
+			if i.baseURL != nil && i.adminURL != nil {
+				break
+			}
+		}
+		errc <- s.Err()
+	}()
+
+	select {
+	case <-time.After(i.startupTimeout):
+		if p := i.cmd.Process; p != nil {
+			p.Kill()
+		}
+		return errors.New("timeout starting child process")
+	case err := <-errc:
+		if err != nil {
+			return fmt.Errorf("error reading web_server.sh process stderr: %v", err)
+		}
+	}
+	if i.baseURL == nil {
+		return errors.New("unable to find webserver URL")
+	}
+	return nil
+}
+
+func (i *instance) NewContext() (ctx context.Context, err error) {
+	ctx = context.Background()
+	var clientSecretPath string
+	if clientSecretPath, err = filepath.Abs("../client-secret.json"); err != nil {
+		return nil, err
+	}
+	// Set GOOGLE_APPLICATION_CREDENTIALS if unset.
+	if _, found := syscall.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); !found {
+		if err = syscall.Setenv("GOOGLE_APPLICATION_CREDENTIALS", clientSecretPath); err != nil {
+			return nil, err
+		}
+	}
+
+	hc, err := google.DefaultClient(ctx,
+		"https://www.googleapis.com/auth/appengine.apis",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var remoteContext context.Context
+	host := fmt.Sprintf("%s:%d", i.host, i.apiPort)
+	remoteContext, err = remote_api.NewRemoteContext(host, hc)
+	return remoteContext, err
+}


### PR DESCRIPTION
Prototype for a firefox end-to-end (webdriver) test of wpt.fyi search functionality in the results page.

Adds `install.sh` to grab selenium, geckodriver, firefox.

Adds `webapp.go` for spinning up `dev_appserver.py` to browse later. This is a copy of the useful parts of [aetest](https://github.com/golang/appengine/tree/master/aetest), the Golang appengine unit test lib. Unfortunately that library ignores the real app.yaml, and is intended for creating contexts only.

Adds `firefox.go` for spinning up firefox using selenium to interact with. Leverages a [third-party](github.com/tebeka/selenium) Golang selenium  webdriver client.