### PR TITLE
Add results/ prefix to the default view

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -142,7 +142,7 @@ found in the LICENSE file.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <path-part path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
+                <path-part prefix='/results' path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
@@ -165,6 +165,8 @@ found in the LICENSE file.
   </template>
 
   <script>
+    const urlToResultsPath = location => location.pathname.replace(/\/results(.+)(\/)?$/, '$1');
+
     /* global TestRunsBase */
     class WPTResults extends TestRunsBase {
       static get is() {
@@ -187,7 +189,7 @@ found in the LICENSE file.
           },
           path: {
             type: String,
-            value: window.location.pathname.replace(/(.+)(\/)$/, '$1')
+            value: urlToResultsPath(window.location)
           },
           pathIsATestFile: {
             type: Boolean,
@@ -330,7 +332,7 @@ found in the LICENSE file.
 
       navigate(event) {
         event.preventDefault();
-        let path = event.target.pathname.replace(/(.+)(\/)$/, '$1');
+        let path = urlToResultsPath(event.target);
         if (path === this.path) {
           return;
         }
@@ -348,7 +350,7 @@ found in the LICENSE file.
             .map(btoa);
           path += `before=${before}&after=${after}`;
         }
-        window.history.pushState({}, '', path);
+        window.history.pushState({}, '', `/results${path}`);
 
         // Send Google Analytics pageview event
         if ('ga' in window) {

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -14,7 +14,8 @@ var templates = template.Must(template.ParseGlob("templates/*.html"))
 func init() {
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
-	http.HandleFunc("/", testHandler)
+	http.HandleFunc("/", testResultsHandler)
+	http.HandleFunc("/results/", testResultsHandler)
 
 	// About wpt.fyi
 	http.HandleFunc("/about", aboutHandler)
@@ -38,5 +39,5 @@ func init() {
 	http.HandleFunc("/api/run", apiTestRunHandler)
 
 	// API endpoint for redirecting to a run's summary JSON blob.
-	http.HandleFunc("/results", resultsRedirectHandler)
+	http.HandleFunc("/api/results", apiResultsRedirectHandler)
 }

--- a/webapp/results_redirect_handler.go
+++ b/webapp/results_redirect_handler.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
-// resultsRedirectHandler is responsible for redirecting to the Google Cloud Storage API
+// apiResultsRedirectHandler is responsible for redirecting to the Google Cloud Storage API
 // JSON blob for the given SHA (or latest) models.TestRun for the given browser.
 //
 // URL format:
@@ -27,7 +27,7 @@ import (
 //   platform: Browser (and OS) of the run, e.g. "chrome-63.0" or "safari"
 //   (optional) run: SHA[0:10] of the test run, or "latest" (latest is the default)
 //   (optional) test: Path of the test, e.g. "/css/css-images-3/gradient-button.html"
-func resultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
+func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		http.Error(w, "Invalid path", http.StatusBadRequest)

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	models "github.com/w3c/wptdashboard/shared"
 )
@@ -21,7 +22,12 @@ import (
 //
 // The browsers initially displayed to the user are defined in browsers.json.
 // The JSON property "initially_loaded" is what controls this.
-func testHandler(w http.ResponseWriter, r *http.Request) {
+func testResultsHandler(w http.ResponseWriter, r *http.Request) {
+	if strings.Index(r.URL.Path, "/results/") != 0 {
+		http.Redirect(w, r, fmt.Sprintf("/results%s", r.URL.Path), 308)
+		return
+	}
+
 	runSHA, err := ParseSHAParam(r)
 	if err != nil {
 		http.Error(w, "Invalid query params", http.StatusBadRequest)


### PR DESCRIPTION
Works a treat.

Running @ https://lukebjerring-results-prefix-dot-wptdashboard.appspot.com

Fix for https://github.com/w3c/wptdashboard/issues/374