### PR TITLE
Metrics cache fetches

### DIFF
--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -68,6 +68,7 @@ func init() {
 }
 
 func main() {
+	flag.Parse()
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	logFileName := "current_metrics.log"

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -9,9 +9,12 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"path"
 	"reflect"
 	"sort"
 	"strings"
@@ -41,6 +44,10 @@ type OutputId struct {
 type Outputter interface {
 	Output(OutputId, interface{}, []interface{}) (interface{}, []interface{}, []error)
 }
+
+var (
+	cachePath = flag.String("cache_path", "", "Path to cache the GCS objects. If empty, fetches are not cached.")
+)
 
 // Encapsulate bucket name and handle; both are needed for some storage
 // read/write routines.
@@ -260,6 +267,15 @@ func (ctx BQContext) Output(id OutputId, metadata interface{},
 // context to load data from bucket.
 func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 	runResults []metrics.TestRunResults) {
+
+	if *cachePath != "" {
+		if _, statErr := os.Stat(*cachePath); os.IsNotExist(statErr) {
+			if err := os.MkdirAll(*cachePath, 0700); err != nil {
+				log.Fatalf("Failed to create cache dir %s: %s", *cachePath, err.Error())
+			}
+		}
+	}
+
 	resultChan := make(chan metrics.TestRunResults, 0)
 	errChan := make(chan error, 0)
 	runResults = make([]metrics.TestRunResults, 0, 100000)
@@ -383,46 +399,96 @@ func processTestRun(ctx *GCSDatastoreContext, testRun *base.TestRun,
 func loadTestResults(ctx *GCSDatastoreContext, testRun *base.TestRun,
 	objName string, resultChan chan metrics.TestRunResults,
 	errChan chan error) {
-	// Read object from GCS
-	obj := ctx.Bucket.Handle.Object(objName)
-	reader, err := obj.NewReader(ctx.Context)
-	if err != nil {
-		errChan <- err
-		return
+
+	var data []byte
+	var err error
+	if *cachePath != "" {
+		filename := path.Join(*cachePath, objName)
+		if data, err = loadCachedFile(filename); err != nil {
+			log.Printf("Error reading cached object %s", objName)
+			errChan <- err
+			return
+		}
 	}
-	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
-	if err != nil {
-		errChan <- err
-		return
+
+	if data == nil {
+		data, err = fetchFile(objName, ctx)
+		if err != nil {
+			if storage.ErrObjectNotExist == err {
+				return
+			}
+			log.Printf("Error fetching object %s", objName)
+			errChan <- err
+			return
+		}
+		if data == nil {
+			return
+		}
+		if *cachePath != "" {
+			err = writeCacheFile(path.Join(*cachePath, objName), data)
+			if err != nil {
+				log.Printf("Failed to write cache object %s", objName)
+				errChan <- err
+				return
+			}
+		}
 	}
 
 	// Unmarshal JSON, which may be gzipped.
 	var results metrics.TestResults
-	var anyResult interface{}
-	if err := json.Unmarshal(data, &anyResult); err != nil {
-		reader2 := bytes.NewReader(data)
-		reader3, err := gzip.NewReader(reader2)
-		if err != nil {
-			errChan <- err
-			return
-		}
+	jsonData := data
+
+	// Try unzip
+	reader2 := bytes.NewReader(data)
+	reader3, err := gzip.NewReader(reader2)
+	if err == nil {
 		defer reader3.Close()
 		unzippedData, err := ioutil.ReadAll(reader3)
 		if err != nil {
+			log.Printf("Error reading unzipped object %s", objName)
 			errChan <- err
 			return
 		}
-		if err := json.Unmarshal(unzippedData, &results); err != nil {
-			errChan <- err
-			return
-		}
-		resultChan <- metrics.TestRunResults{testRun, &results}
-	} else {
-		if err := json.Unmarshal(data, &results); err != nil {
-			errChan <- err
-			return
-		}
-		resultChan <- metrics.TestRunResults{testRun, &results}
+		jsonData = unzippedData
 	}
+
+	if err := json.Unmarshal(jsonData, &results); err != nil {
+		log.Printf("Error unmarshalling object %s", objName)
+		errChan <- err
+		return
+	}
+	resultChan <- metrics.TestRunResults{testRun, &results}
+}
+
+func loadCachedFile(filename string) ([]byte, error) {
+	if _, statErr := os.Stat(filename); os.IsNotExist(statErr) {
+		return nil, nil
+	}
+	return ioutil.ReadFile(filename)
+}
+
+func writeCacheFile(filename string, data []byte) error {
+	// Make parent dir(s).
+	func() {
+		pieces := strings.Split(filename, "/")
+		parentDir := strings.Join(pieces[:len(pieces)-1], "/")
+		if err := os.MkdirAll(parentDir, 0700); err != nil {
+			log.Printf("Failed to make parent dir %s", parentDir)
+		}
+	}()
+
+	// Write cache file.
+	return ioutil.WriteFile(filename, data, 0700)
+}
+
+func fetchFile(objName string, ctx *GCSDatastoreContext) ([]byte, error) {
+	// Read object from GCS
+	obj := ctx.Bucket.Handle.Object(objName)
+	reader, err := obj.NewReader(ctx.Context)
+	if err != nil {
+		log.Printf("Error loading object %s: %s", objName, err.Error())
+		return nil, err
+	}
+	defer reader.Close()
+	return ioutil.ReadAll(reader)
 }


### PR DESCRIPTION
Helps with https://github.com/w3c/wptdashboard/issues/454, as the server throttles us and eventually demands authentication (throwing a 401) and this kills the Go program, forcing us to start again.